### PR TITLE
Fix mobile directory view #173346911

### DIFF
--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -646,6 +646,16 @@ table {
   }
 }
 
+@mixin mobile-header-base {
+  content: attr(data-th);
+  padding-right: 0.5rem;
+  max-width: 50%;
+  text-align: left;
+  font-weight: $table-value-weight;
+  letter-spacing: .1rem;
+  text-transform: uppercase;
+}
+
 @mixin mobile-table-styling {
   .table-pricing-wrapper {
     margin-top: 0;
@@ -690,8 +700,13 @@ table {
     td {
       position: relative;
 
+      small {
+        display: inline-block;
+      }
+
       &.is-subtitled, &.is-subtitled-nested {
         text-align: right;
+        padding-left: calc(50% + 0.5rem);
       }
 
       &.is-subtitled-nested {
@@ -700,13 +715,10 @@ table {
       }
 
       &.is-subtitled::before, &.is-subtitled-nested::before {
-        content: attr(data-th);
+        @include mobile-header-base();
         position: absolute;
         line-height: 1;
         left: 0;
-        font-weight: $table-value-weight;
-        letter-spacing: .1rem;
-        text-transform: uppercase;
       }
 
       &.is-subtitled-nested::before {
@@ -717,10 +729,7 @@ table {
       }
 
       &.is-supertitled::before {
-        content: attr(data-th);
-        font-weight: $table-value-weight;
-        letter-spacing: .1rem;
-        text-transform: uppercase;
+        @include mobile-header-base();
         margin-left: -1rem;
       }
 


### PR DESCRIPTION
Fix overlapping headers and cells by:
- Setting the max width of header and cells to 50%
- Add a padding of 1rem between th and td so text never touches
- Set small text to be inline-block so that it wraps to a new line before breaking other text

## Screenshot: english at 375px (iphone 6)
<img src="https://user-images.githubusercontent.com/64036574/88975964-0fb65880-d270-11ea-9ce6-c565811a7a2f.png" width="230" />

## Screenshot: english at 320px
<img src="https://user-images.githubusercontent.com/64036574/88975956-0c22d180-d270-11ea-9b77-3f491427bd3f.png" width="230" />

## Screenshot: tagalog at 375px (iphone 6)
<img src="https://user-images.githubusercontent.com/64036574/88975828-ca922680-d26f-11ea-8e90-49672ba02683.png" width="230" />

## Screenshot: tagalog at 320px (iphone 5)
Notice that the headers get cut off, this is because their height isn't part of the parent height calculation. This is a lot harder to fix, as removing position: absolute from the header has ripple effects that require lots of other changes. I recommend we merge this fix as is and either create a separate ticket to fix this or we wait until the re-write.
<img src="https://user-images.githubusercontent.com/64036574/88975823-c6fe9f80-d26f-11ea-86c8-89c4c5b5cbb0.png" width="230" />
