### PR TITLE
Features/indigenous specific group #173951931

### DIFF
--- a/components/02-molecules/components/accordion-plus-minus.html
+++ b/components/02-molecules/components/accordion-plus-minus.html
@@ -7,33 +7,7 @@
       {{> @icon-plus-minus active="false" }}
     </div>
     <div id="panel-1-a" class="content">
-      <div class="checkbox-group" role="group">
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="preferences" value="panel-1-a-opt-1" id="panel-1-a-opt-1">
-            <label class="checkbox-and-label"for="panel-1-a-opt-1">
-              Option 1
-            </label>
-        </div>
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="preferences" value="panel-1-a-opt-2" id="panel-1-a-opt-2">
-            <label class="checkbox-and-label"for="panel-1-a-opt-2">
-              Option 2
-            </label>
-        </div>
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="preferences" value="panel-1-a-opt-3" id="panel-1-a-opt-3">
-            <label class="checkbox-and-label"for="panel-1-a-opt-3">
-              Option 3
-            </label>
-        </div>
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="Other checkbox" value="panel-1-a-opt-4" id="panel-1-a-opt-4">
-            <label class="checkbox-and-label" for="panel-1-a-opt-4">
-              Other
-            </label>
-            <input class="checkbox-text-input" type="text" name="Other text" value="" placeholder="Please specify..." id="panel-1-a-opt-4-text">
-        </div>
-      </div>
+      <div class="checkbox-group" role="group"></div>
     </div>
   </dd>
   <dd class="accordion-navigation active">
@@ -74,6 +48,7 @@
             <label class="checkbox-and-label"for="panel-1-b-opt-5">
               Option 5
             </label>
+            <input class="checkbox-text-input" type="text" name="Other text 2" value="" placeholder="Specific group" id="panel-1-a-opt-4-text">
         </div>
         <div class="checkbox-block-accordion">
             <input type="checkbox" name="preferences" value="panel-1-b-opt-6" id="panel-1-b-opt-6">
@@ -94,12 +69,7 @@
     </div>
     <div id="panel-1-c" class="content">
       <div class="checkbox-group" role="group">
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="preferences" value="panel-1-c-opt-1" id="panel-1-c-opt-1">
-            <label class="checkbox-and-label"for="panel-1-c-opt-1">
-              Option 1
-            </label>
-        </div>
+        <div class="checkbox-block-accordion"></div>
       </div>
     </div>
   </dd>
@@ -117,12 +87,7 @@
     </div>
     <div id="panel-1-d" class="content">
       <div class="checkbox-group" role="group">
-        <div class="checkbox-block-accordion">
-            <input type="checkbox" name="preferences" value="panel-1-d-opt-1" id="panel-1-d-opt-1">
-            <label class="checkbox-and-label"for="panel-1-d-opt-1">
-              Option 1
-            </label>
-        </div>
+        <div class="checkbox-block-accordion"></div>
       </div>
     </div>
   </dd>

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -188,7 +188,9 @@ $accordion-text-color: #4D4D4D;
 
     .checkbox-text-input {
       width: auto;
-      margin-bottom: 0;
+      margin: 0;
+      margin-top: rem-calc(4);
+      margin-bottom: rem-calc(4);
     }
   }
 }

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -171,30 +171,26 @@ $accordion-text-color: #4D4D4D;
       flex-grow: 1;
     }
 
-    input[type="checkbox"] + label {
-      margin-top: 0;
-      margin-bottom: 0;
-      display: flex;
-      align-items: center;
-      min-height: rem-calc(44);
-    }
-
     input[type="checkbox"] + label::before {
       flex-shrink: 0;
     }
 
     .checkbox-and-label {
+      display: flex;
+      align-items: center;
+      min-height: rem-calc(44);
       padding-right: rem-calc(16);
-      margin-right: rem-calc(-30);
+
+      margin: 0;
     }
 
     .checkbox-text-input {
       width: auto;
       max-width: 100%;
-      margin: 0;
+
+      // Add small vertical margin so multiple text inputs won't touch.
       margin-top: rem-calc(4);
       margin-bottom: rem-calc(4);
-      margin-left: rem-calc(30);
     }
   }
 }

--- a/public/toolkit/styles/molecules/_accordion.scss
+++ b/public/toolkit/styles/molecules/_accordion.scss
@@ -172,7 +172,8 @@ $accordion-text-color: #4D4D4D;
     }
 
     input[type="checkbox"] + label {
-      margin: 0;
+      margin-top: 0;
+      margin-bottom: 0;
       display: flex;
       align-items: center;
       min-height: rem-calc(44);
@@ -184,13 +185,16 @@ $accordion-text-color: #4D4D4D;
 
     .checkbox-and-label {
       padding-right: rem-calc(16);
+      margin-right: rem-calc(-30);
     }
 
     .checkbox-text-input {
       width: auto;
+      max-width: 100%;
       margin: 0;
       margin-top: rem-calc(4);
       margin-bottom: rem-calc(4);
+      margin-left: rem-calc(30);
     }
   }
 }


### PR DESCRIPTION
- Add padding between text and text input
- Add padding between multiple text inputs
- Don't allow text input to go past the edge of the accordion

## x- Large, shows padding btwn inputs
![- 2020-08-06 at 3 03 48 PM](https://user-images.githubusercontent.com/64036574/89587274-2d4a6b80-d7f6-11ea-954a-e2bfd964063a.png)


## Large, shows padding btwn input and label text and indentation
![- 2020-08-06 at 3 03 55 PM](https://user-images.githubusercontent.com/64036574/89587279-30ddf280-d7f6-11ea-8dfe-8828eaed9455.png)


## very small, shows input stay within border
![- 2020-08-06 at 3 04 34 PM](https://user-images.githubusercontent.com/64036574/89587284-34717980-d7f6-11ea-8cef-b2139a630c7d.png)


