### PR TITLE
Fix dropdown patterns

### DIFF
--- a/components/03-organisms/modal--status-open.html
+++ b/components/03-organisms/modal--status-open.html
@@ -6,9 +6,9 @@
   <section class="modal-inner">
     <div class="form-group">
       <h2 class="form-label">Status/Comment</h2>
-      <div class="dropdown-menu-wrapper">
+      <div class="dropdown">
         <button
-          class="button dropdown-button has-icon--right margin-bottom--half expand is-processing {{default classes ''}}"
+          class="button dropdown-button has-icon--right expand is-processing {{default classes ''}}"
           href="#"
           aria-expanded="false"
         >
@@ -19,17 +19,19 @@
           </span>
           {{default text 'Processing'}}
         </button>
-        <ul class="dropdown-menu" role="listbox" aria-hidden="true" aria-activedescendant tabindex="-1">
-          <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
-          <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
-          <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
-          <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
-          <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
-          <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
-          <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
-          <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
-          <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
-        </ul>
+        <div class="dropdown-menu-wrapper">
+          <ul class="dropdown-menu" role="listbox" aria-hidden="true" aria-activedescendant tabindex="-1">
+            <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
+            <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
+            <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
+            <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
+            <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
+            <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
+            <li class="dropdown-menu_item is-processing" role="option" aria-selected="false"><a href="#">This is a link</a></li>
+            <li class="dropdown-menu_item is-approved" role="option" aria-selected="false"><a href="#">This is another</a></li>
+            <li class="dropdown-menu_item is-disqualified is-selected" role="option" aria-selected="true"><a href="#">Yet another</a></li>
+          </ul>
+        </div>
       </div>
       {{> @button-dropdown classes="dropdown is-processing margin-bottom--half expand" text="Processing"}}
       <label class="sr-only" for="textarea-id" id="textarea-label-id">Comment</label>

--- a/public/toolkit/styles/molecules/_dropdowns.scss
+++ b/public/toolkit/styles/molecules/_dropdowns.scss
@@ -90,10 +90,20 @@
   border-top: 1px solid $f-dropdown-border-color;
 }
 
-.dropdown-menu-wrapper {
+.dropdown {
+  margin-bottom: 1rem;
   position: relative;
 
+  .dropdown-menu-wrapper {
+    position: absolute;
+    width: 100%;
+  }
+
+  .dropdown-button {
+    margin-bottom: 0;
+  }
   .dropdown-menu {
     max-width: 100%;
+    position: relative;
   }
 }

--- a/public/toolkit/styles/molecules/_dropdowns.scss
+++ b/public/toolkit/styles/molecules/_dropdowns.scss
@@ -91,7 +91,6 @@
 }
 
 .dropdown {
-  margin-bottom: 1rem;
   position: relative;
 
   .dropdown-menu-wrapper {


### PR DESCRIPTION
The pattern library example uses classes very differently to how they're used in Partners.

This change:
- Converts the pattern library example to use the classes that are used in partners
- Fixes the dropdown so it doesn't need to be manually positioned in the react code. Now instead of adding margin to the dropdown-button, you'd add it to the `dropdown` div instead. That way the absolutely positioned dropdown appears directly under the dropdown-button, not under the dropdown-button + the button's margin.


Affect on partners: Allows us to remove any custom positioning logic, dropdown is now positioned correctly no matter what, and the button can have whatever margin it wants, as long as it's added to the `dropdown` component, not the `dropdown-button` component.

Affect on webapp: None, webapp doesn't use these dropdowns.

![- 2020-08-24 at 12 43 07 PM](https://user-images.githubusercontent.com/64036574/91105463-fc0ad180-e624-11ea-9ca3-572e9734866b.png)
