### PR TITLE
Add substatus text class #DAHLIAFE-25

### DIFF
--- a/components/02-molecules/components/status-history-sidebar.html
+++ b/components/02-molecules/components/status-history-sidebar.html
@@ -43,6 +43,9 @@
                 August 4, 2020
               </div>
             </div>
+            <div class="item-substatus-text">
+              Written approval
+            </div>
             <div class="status-item-text">
               Just approved the lease!
             </div>

--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -51,13 +51,13 @@ h3.status-history-label {
     .item-substatus-text {
       @include responsive-text-size('small');
       color: $steel;
-      width: 100%
+      width: 100%;
     }
 
     .status-item-text {
       @include responsive-text-size('small');
       color: $jet;
-      width: 100%
+      width: 100%;
     }
   }
 }

--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -48,6 +48,12 @@ h3.status-history-label {
       }
     }
 
+    .item-substatus-text {
+      @include responsive-text-size('small');
+      color: $steel;
+      width: 100%
+    }
+
     .status-item-text {
       @include responsive-text-size('small');
       color: $jet;


### PR DESCRIPTION
Jira ticket: [#DAHLIAFE-25](https://sfgovdt.jira.com/browse/DAHLIAFE-25?atlOrigin=eyJpIjoiMDFlNmQ2NDczNTc5NGQwYTg2ZjNiZjQ4YzBiMTIzYzYiLCJwIjoiaiJ9)

[Designs](https://www.figma.com/file/FFaD5ZlsL9QzpTsA8yP7iI/scooting-partners-supp-app-170930954?node-id=159%3A0)


When I added the pattern for the sidebar I missed that status items can have substatuses, that should show as slightly gray-er text above the comment text.

### Screenshot: show "Written approval" substatus text
![- 2020-08-24 at 4 37 20 PM](https://user-images.githubusercontent.com/64036574/91106675-1befc480-e628-11ea-891c-d35b2f44d0dc.png)
