### PR TITLE
Set width on dropdown item, not child button #DAHLIAFE-25

### DIFF
--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -1,6 +1,8 @@
 $sidebar-button-margin: 1rem;
 $sticky-top-margin: 2rem;
 
+$width-button-half-column: calc(50% - #{$sidebar-button-margin / 2});
+
 .page-content-column {
   padding-left: 0;
 }
@@ -67,8 +69,18 @@ button.save-button {
   flex-wrap: wrap;
   width: 100%;
 
+  .dropdown {
+    // Have to set button width on the dropdown wrapper instead of the
+    // button itself.
+    width: $width-button-half-column;
+
+    .dropdown-button {
+      width: 100%;
+    }
+  }
+
   button, .button {
-    width: calc(50% - #{$sidebar-button-margin / 2});
+    width: $width-button-half-column;
     margin-bottom: 0;
     word-wrap: break-word;
   }


### PR DESCRIPTION
Partners implementation issue [#DAHLIAFE-37](https://sfgovdt.jira.com/browse/DAHLIAFE-37?atlOrigin=eyJpIjoiYWJkMDY2MWVlNzM4NDE3NmIxYjhjYzBlOGQ0ZTNlMzkiLCJwIjoiaiJ9)
Pattern library issue [#DAHLIAFE-25](https://sfgovdt.jira.com/browse/DAHLIAFE-25?atlOrigin=eyJpIjoiYWJkMDY2MWVlNzM4NDE3NmIxYjhjYzBlOGQ0ZTNlMzkiLCJwIjoiaiJ9)

While implementing the sidebar components, I found that my [recent change](https://github.com/SFDigitalServices/sf-dahlia-pattern-library/pull/137) to fix dropdown patterns broke the way we're using dropdown buttons in the sidebar. This fixes the issue by setting the button width on the .dropdown div, not the child button.