### PR TITLE
[DAH-37] Simplify pill styling

### DIFF
--- a/components/01-atoms/pills/status-pill.html
+++ b/components/01-atoms/pills/status-pill.html
@@ -1,62 +1,62 @@
 <div>
   <div class="padding-bottom">
-    <div class="status-pill-processing">
-      <div class="pill-text">Pill Text</div>
+    <div class="status-pill is-processing">
+      Pill Text
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-processing">
-      <div class="pill-text">Pill</div>
+    <div class="status-pill is-processing">
+      Pill
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-processing">
-      <div class="pill-text">Pill with long name</div>
+    <div class="status-pill is-processing">
+      Pill with long name
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-processing">
-      <div class="pill-text">processing</div>
+    <div class="status-pill is-processing">
+      processing
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-processing">
-      <div class="pill-text">processing</div>
+    <div class="status-pill is-processing">
+      processing
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-approved">
-      <div class="pill-text">approved</div>
+    <div class="status-pill is-approved">
+      approved
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-disqualified">
-      <div class="pill-text">disqualified</div>
+    <div class="status-pill is-disqualified">
+      disqualified
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-appealed">
-      <div class="pill-text">appealed</div>
+    <div class="status-pill is-appealed">
+      appealed
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-withdrawn">
-      <div class="pill-text">withdrawn</div>
+    <div class="status-pill is-withdrawn">
+      withdrawn
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-leased">
-      <div class="pill-text">leased</div>
+    <div class="status-pill is-leased">
+      leased
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-waitlisted">
-      <div class="pill-text">waitlisted</div>
+    <div class="status-pill is-waitlisted">
+      waitlisted
     </div>
   </div>
   <div class="padding-bottom">
-    <div class="status-pill-no-status">
-      <div class="pill-text">No Status</div>
+    <div class="status-pill is-no-status">
+      No Status
     </div>
   </div>
 </div>

--- a/components/02-molecules/components/status-history-sidebar--with-show-all-link.html
+++ b/components/02-molecules/components/status-history-sidebar--with-show-all-link.html
@@ -36,8 +36,8 @@
         <div class="status-items">
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-approved">
-                <div class="pill-text">approved</div>
+              <div class="status-pill is-approved">
+                approved
               </div>
               <div class="status-item-date">
                 August 4, 2020
@@ -49,8 +49,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-processing">
-                <div class="pill-text">processing</div>
+              <div class="status-pill is-processing">
+                processing
               </div>
               <div class="status-item-date">
                 August 3, 2020
@@ -62,8 +62,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 2, 2020
@@ -75,8 +75,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020

--- a/components/02-molecules/components/status-history-sidebar--with-show-recent-link.html
+++ b/components/02-molecules/components/status-history-sidebar--with-show-recent-link.html
@@ -36,8 +36,8 @@
         <div class="status-items">
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-approved">
-                <div class="pill-text">approved</div>
+              <div class="status-pill is-approved">
+                approved
               </div>
               <div class="status-item-date">
                 August 4, 2020
@@ -49,8 +49,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-processing">
-                <div class="pill-text">processing</div>
+              <div class="status-pill is-processing">
+                processing
               </div>
               <div class="status-item-date">
                 August 3, 2020
@@ -62,8 +62,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 2, 2020
@@ -75,8 +75,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -88,8 +88,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -101,8 +101,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -114,8 +114,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -127,8 +127,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -140,8 +140,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -153,8 +153,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -166,8 +166,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020
@@ -179,8 +179,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 1, 2020

--- a/components/02-molecules/components/status-history-sidebar.html
+++ b/components/02-molecules/components/status-history-sidebar.html
@@ -36,8 +36,8 @@
         <div class="status-items">
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-approved">
-                <div class="pill-text">approved</div>
+              <div class="status-pill is-approved">
+                approved
               </div>
               <div class="status-item-date">
                 August 4, 2020
@@ -52,8 +52,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-processing">
-                <div class="pill-text">processing</div>
+              <div class="status-pill is-processing">
+                processing
               </div>
               <div class="status-item-date">
                 August 3, 2020
@@ -65,8 +65,8 @@
           </div>
           <div class="status-item">
             <div class="status-item-header">
-              <div class="status-pill-no-status">
-                <div class="pill-text">No status</div>
+              <div class="status-pill is-no-status">
+                No status
               </div>
               <div class="status-item-date">
                 August 2, 2020

--- a/public/toolkit/styles/atoms/_pills.scss
+++ b/public/toolkit/styles/atoms/_pills.scss
@@ -43,7 +43,7 @@
   }
 
   &.is-withdrawn {
-    @include pill-color($bg-color: $warn);
+    @include pill-color($bg-color: $warn, $text-color: $black);
   }
 
   &.is-leased {

--- a/public/toolkit/styles/atoms/_pills.scss
+++ b/public/toolkit/styles/atoms/_pills.scss
@@ -20,6 +20,8 @@
   display: table;
   border-radius: rem-calc(4px);
 
+  @include pill-color();
+
   &.is-no-status {
     @include pill-color($bg-color: $white, $border-color: $steel, $text-color: $steel);
   }

--- a/public/toolkit/styles/atoms/_pills.scss
+++ b/public/toolkit/styles/atoms/_pills.scss
@@ -1,58 +1,54 @@
-.pill-text {
+@mixin pill-color($bg-color: $aluminum, $border-color: $bg-color, $text-color: $white) {
+  background-color: $bg-color;
+  border: 2px solid $border-color;
+  color: $text-color;
+}
+
+.status-pill {
   @include responsive-text-size('tiny');
   font-family: $alt-font-family;
   font-weight: $t-semi;
   line-height: calc(1.5rem - 4px);
-  color: white;
   text-transform: uppercase;
   text-align: center;
-}
 
-@mixin pill($bg-color: $aluminum, $border-color: $bg-color, $text-color: $white) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   min-width: rem-calc(106px);
 
   // Required to fix width to content
   display: table;
-
-  background-color: $bg-color;
-  border: 2px solid $border-color;
   border-radius: rem-calc(4px);
 
-  .pill-text {
-    color: $text-color;
+  &.is-no-status {
+    @include pill-color($bg-color: $white, $border-color: $steel, $text-color: $steel);
   }
-}
 
-.status-pill-no-status {
-  @include pill($bg-color: $white, $border-color: $steel, $text-color: $steel);
-}
+  &.is-processing {
+    @include pill-color($bg-color: $aluminum);
+  }
 
-.status-pill-processing {
-  @include pill($bg-color: $aluminum, $text-color: $white);
-}
+  &.is-approved {
+    @include pill-color($bg-color: $deep);
+  }
 
-.status-pill-approved {
-  @include pill($bg-color: $deep, $text-color: $white);
-}
+  &.is-disqualified {
+    @include pill-color($bg-color: $alert);
+  }
 
-.status-pill-disqualified {
-  @include pill($bg-color: $alert, $text-color: $white);
-}
+  &.is-appealed {
+    @include pill-color($bg-color: $royal);
+  }
 
-.status-pill-appealed {
-  @include pill($bg-color: $royal, $text-color: $white);
-}
+  &.is-withdrawn {
+    @include pill-color($bg-color: $warn);
+  }
 
-.status-pill-withdrawn {
-  @include pill($bg-color: $warn, $text-color: $black);
-}
+  &.is-leased {
+    @include pill-color($bg-color: $success);
+  }
 
-.status-pill-leased {
-  @include pill($bg-color: $success, $text-color: $white);
-}
-
-.status-pill-waitlisted {
-  @include pill($bg-color: $attention, $text-color: $white);
+  &.is-waitlisted {
+    @include pill-color($bg-color: $attention);
+  }
 }

--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -9,14 +9,15 @@ $width-button-half-column: calc(50% - #{$sidebar-button-margin / 2});
 
 .sidebar-column {
   padding-right: 0;
+}
 
-  .sidebar-content {
-    display: flex;
-    flex-direction: column;
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
 
-    .show-all-updates-toggle {
-      padding-bottom: 2rem;
-    }
+  .show-all-updates-toggle {
+    padding-bottom: 2rem;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Jira ticket: [[#DAH-37](https://sfgovdt.jira.com/browse/DAH-37)]

We don't actually need the separate `pill-text` divs, we can just add the text styles to the `status-pill` parent. Also, change the class names to be separate classes for the pill and styling.

I also moved the sidebar component styling outside of the sidebar column, since while building the components I realized you should be able to have the sidebar styled properly whether or not it's in a column.