### PR TITLE
Update styles for new supplemental application layout  [DAH-36]

### DIFF
--- a/components/01-atoms/tables/table--preferences.html
+++ b/components/01-atoms/tables/table--preferences.html
@@ -75,7 +75,7 @@
     {{#if editable}}
       <tr class="tr-expand-content is-expanded" aria-hidden="false">
         <td colspan="7" class="td-expand-nested no-padding">
-          <div class="app-{{default editable ''}} expand-wide scrollable-table-nested">
+          <div class="app-{{default editable ''}} scrollable-table-nested">
             <div class="form-grid row">
               <div class="form-grid_item small-12 medium-6 large-3 column">
                 <div class="form-group">

--- a/public/toolkit/styles/atoms/_forms.scss
+++ b/public/toolkit/styles/atoms/_forms.scss
@@ -133,8 +133,8 @@ label {
 
 // Additional input helper text
 .form-note {
-  @include responsive-text-size('small');
-  @include type-weight(semi);
+  @include responsive-text-size('tiny');
+  @include type-weight(normal);
   color: $steel;
   margin-bottom: 0;
 

--- a/public/toolkit/styles/atoms/_tables.scss
+++ b/public/toolkit/styles/atoms/_tables.scss
@@ -281,25 +281,8 @@ table {
   overflow-x: auto;
 }
 
-.scrollable-table-container-under-xlarge {
-  overflow-x: auto;
-
-  .scrollable-table-nested.expand-wide {
-    width: calc(100vw - 4rem);
-
-    @media #{$xlarge-up} {
-      width: auto;
-    }
-
-    @media only screen and (max-width: $large-breakpoint) {
-      @include scut-margin(n 0);
-      @include scut-padding(n 1rem);
-    }
-  }
-
-  @media #{$xlarge-up} {
-    overflow-x: visible;
-  }
+.table-container-overflow-scroll {
+  overflow-x: scroll;
 }
 
 // More practical CSS...

--- a/public/toolkit/styles/organisms/_app-card.scss
+++ b/public/toolkit/styles/organisms/_app-card.scss
@@ -184,6 +184,7 @@
 
 .app-card_h3 {
   @include responsive-text-size('delta');
+  @include type-weight('semi');
 
   .t-sans {
     font-family: $alt-font-family;


### PR DESCRIPTION
This PR:

- Updates form note to make it tiny and not-bold
- Makes app card h3 semi-bold
- Adds class to use to have the preferences and rental assistance table scroll when there's overflow