### PR TITLE
Polish sidebar padding [DAH-37]

### DIFF
--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -22,7 +22,7 @@ $width-button-half-column: calc(50% - #{$sidebar-button-margin / 2});
 }
 
 h3.status-history-label {
-  margin-top: 1rem;
+  margin-top: 3rem;
 }
 
 .status-items {
@@ -106,6 +106,7 @@ button.save-button {
   }
 
   h3.status-history-label {
+    margin-top: 1rem;
     margin-bottom: 2rem;
   }
 

--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -22,7 +22,7 @@ $width-button-half-column: calc(50% - #{$sidebar-button-margin / 2});
 }
 
 h3.status-history-label {
-  margin-top: 3rem;
+  margin-top: 1rem;
 }
 
 .status-items {
@@ -96,6 +96,19 @@ button.save-button {
 // At small and medium sizes, we want the sidebar docked below page
 // content, and with status + save buttons below the status history
 @media (max-width: $medium-breakpoint) {
+  .sidebar-content {
+    padding-left: 2rem;
+    padding-right: 2rem;
+
+    .show-all-updates-toggle {
+      padding-bottom: 1rem;
+    }
+  }
+
+  h3.status-history-label {
+    margin-bottom: 2rem;
+  }
+
   // at small size, remove foundation column gutters
   .page-content-column, .sidebar-column {
     padding-left: 0;
@@ -112,11 +125,6 @@ button.save-button {
 // to be scrollable so it fits on the screen.
 @media #{$large-up} {
   .sidebar-column {
-    // for large screens, we need column containing fixed sidebar to be
-    // the same height as column it's next to, so sticky sidebar can scroll
-    // down the whole screen.
-    height: 100%;
-
     .sticky-sidebar-large-up {
       position: -webkit-sticky;
       position: sticky;


### PR DESCRIPTION
[DAH-37]

- reduce the padding on top of the status history at small screen sizes
  - This is because the element above has its own bottom margin, they should add to 3rem.
- Remove percent height on the sidebar column. This is so that we can use flex's align-items: stretch to make all children stretch to fill the parent.
- Add side padding to the sidebar-content at small screen sizes. This is the same padding the content-sections have
- Shrink bottom padding on the show/hide link at small screen sizes to match designs

[DAH-37]: https://sfgovdt.jira.com/browse/DAH-37