### PR TITLE
Add background white for nested inline modal DAH-90

### DIFF
--- a/public/toolkit/styles/organisms/_app-card.scss
+++ b/public/toolkit/styles/organisms/_app-card.scss
@@ -125,13 +125,16 @@
   }
 }
 
-.app-editable {
+.inline-modal {
   @include scut-padding(2rem n);
   background: $dust;
   z-index: 10;
   position: relative;
   overflow: auto;
 
+  .inline-modal {
+    background: $white
+  }
   &.expand-wide {
     @include scut-margin(n -2rem);
     @include scut-padding(n 3rem);

--- a/public/toolkit/styles/organisms/_app-card.scss
+++ b/public/toolkit/styles/organisms/_app-card.scss
@@ -132,7 +132,7 @@
   position: relative;
   overflow: auto;
 
-  .inline-modal {
+  &.white-background {
     background: $white
   }
   &.expand-wide {


### PR DESCRIPTION
DAH-90

This PR:
1. Renames app-editable to be inline modal
1. Adds a background of white if there's an inline modal inside of an inline modal. 

See this image of this in action in partners
![image](https://user-images.githubusercontent.com/11825994/91918671-73b9ab80-ec78-11ea-831f-29fabe825bd2.png)
