### PR TITLE
Update inline modal to give it a width of 100%

### DIFF
--- a/public/toolkit/styles/organisms/_app-card.scss
+++ b/public/toolkit/styles/organisms/_app-card.scss
@@ -131,6 +131,7 @@
   z-index: 10;
   position: relative;
   overflow: auto;
+  width: 100%;
 
   &.white-background {
     background: $white


### PR DESCRIPTION
Fixes rental assistance issue where inline modal was not taking up 100% of available width https://github.com/SFDigitalServices/sf-dahlia-lap/pull/394
