### PR TITLE
Update hover background color for Dropdowns

### DIFF
--- a/public/toolkit/styles/molecules/_dropdowns.scss
+++ b/public/toolkit/styles/molecules/_dropdowns.scss
@@ -62,7 +62,7 @@
   }
 
   &:hover, &:focus {
-    background-color: $mist;
+    background-color: $vapor;
   }
 
 

--- a/public/toolkit/styles/molecules/_dropdowns.scss
+++ b/public/toolkit/styles/molecules/_dropdowns.scss
@@ -61,13 +61,10 @@
     }
   }
 
-  // Link
-  a {
-    &:focus {
-      background-color: $f-dropdown-list-hover-bg;
-      text-decoration: none;
-    }
+  &:hover, &:focus {
+    background-color: $mist;
   }
+
 
   // Checkboxes
   .checkbox {


### PR DESCRIPTION
This PR makes the hover state for dropdowns a bit more visible.
Change was implemented in partners in https://github.com/SFDigitalServices/sf-dahlia-lap/pull/408/files
Before: 
![image](https://user-images.githubusercontent.com/11825994/93943315-21076880-fce7-11ea-8b4f-c643b09678bc.png)

After:
![image](https://user-images.githubusercontent.com/11825994/93943273-046b3080-fce7-11ea-8fb9-ee93024b2500.png)


The blue styling for selected is coming from the Dropdown component. 
DAH-124