### PR TITLE
Add form note small style [DAH-142]

### DIFF
--- a/public/toolkit/styles/atoms/_forms.scss
+++ b/public/toolkit/styles/atoms/_forms.scss
@@ -154,6 +154,10 @@ label {
     @include responsive-text-size('micro');
   }
 
+  &.small {
+    @include responsive-text-size('small');
+  }
+
   &.max-width {
     max-width: rem-calc(640);
   }


### PR DESCRIPTION
Fixes a text issue with [DAH-142]

The text style was 1px off, this adds a "small" style that sets the text to the correct value.

[DAH-142]: https://sfgovdt.jira.com/browse/DAH-142