### PR TITLE
Add pattern for search input DAH-159

### DIFF
--- a/components/01-atoms/forms/input-search.html
+++ b/components/01-atoms/forms/input-search.html
@@ -1,0 +1,10 @@
+<div class="search">
+  <input type="text" class="has-value" placeholder="Enter search terms..."/>
+  <button
+    class='ui-medium ui-icon i-aluminum button-link search-icon'
+  >
+    <svg>
+      <use xlink:href="#i-close-round" />
+    </svg>
+  </button>
+</div>

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -383,3 +383,26 @@ input.icon-input-field {
   line-height: $icon-input-height;
   height: $icon-input-height;
 }
+
+// Search text field with x icon to clear
+// Javascript must be added to
+$clear-icon-margin: 13.5px;
+$clear-icon-height: 16px;
+.search {
+  display: inline-block;
+  position: relative;
+
+  input {
+    width: 15.5rem;
+  }
+  input.has-value {
+    // Center the icon within the padding. Subtract 1px to account for the border.
+    padding-right: rem-calc(($clear-icon-margin - 1) * 2 + $clear-icon-height);
+  }
+
+  .button, .search-icon {
+    position: absolute;
+    right: $clear-icon-margin;
+    top: $clear-icon-margin;
+  }
+}

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -387,17 +387,18 @@ input.icon-input-field {
 // Search text field with x icon to clear
 // Javascript must be added to
 $clear-icon-margin: 13.5px;
-$clear-icon-height: 16px;
+$clear-icon-size: 16px;
 .search {
   display: inline-block;
   position: relative;
+  width: 100%;
 
   input {
-    width: 15.5rem;
+    width: 100%;
   }
   input.has-value {
     // Center the icon within the padding. Subtract 1px to account for the border.
-    padding-right: rem-calc(($clear-icon-margin - 1) * 2 + $clear-icon-height);
+    padding-right: rem-calc(($clear-icon-margin - 1) * 2 + $clear-icon-size);
   }
 
   .button, .search-icon {


### PR DESCRIPTION
DAH-159

This PR adds a pattern for the search input along with some styles to get it to work.
The pattern here doesn't have the interactions that we'll have in Partners. Instead of only showing the icon when there's text present, this pattern just shows the case with the clear icon present. The clear icon is also not functional in this example. 

To QA:
- Review the input search pattern locally: http://localhost:3001/components/detail/input-search
![image](https://user-images.githubusercontent.com/11825994/97332157-8273a780-1850-11eb-9b7f-c61bbfa29459.png)
