### PR TITLE
Fix checkbox and dropdown button styling DAH-564

### DIFF
--- a/public/toolkit/styles/molecules/_dropdowns.scss
+++ b/public/toolkit/styles/molecules/_dropdowns.scss
@@ -108,9 +108,6 @@
     width: 100%;
   }
 
-  .dropdown-button {
-    margin-bottom: 0;
-  }
   .dropdown-menu {
     max-width: 100%;
     position: relative;

--- a/public/toolkit/styles/molecules/_filter-row.scss
+++ b/public/toolkit/styles/molecules/_filter-row.scss
@@ -17,6 +17,9 @@
     justify-content: flex-end;
   }
 }
+.filter-group.filter-group--left {
+  justify-content: flex-start;
+}
 
 .filter-group_item,
 .filter-group_item__large,

--- a/public/toolkit/styles/molecules/_inputs.scss
+++ b/public/toolkit/styles/molecules/_inputs.scss
@@ -72,6 +72,10 @@ input[type="radio"] + label::before {
   width: 1.25rem;
 }
 
+input[type="checkbox"].no-margin + label::before {
+  margin-right: 0rem;
+}
+
 input[type="radio"] + label::before {
   height:1.2rem;
   width: 1.2rem;


### PR DESCRIPTION
DAH-564

This PR:
1. Removes unnecessary margin from the dropdown button class (maybe should check the unit dropdown actually)
1. Adds a no-margin class that can be added to the checkbox + label combo to get rid of the right margin on checkboxes