### PR TITLE
Fix status update buttons [DAH-564]

### DIFF
--- a/public/toolkit/styles/molecules/_status-history-sidebar.scss
+++ b/public/toolkit/styles/molecules/_status-history-sidebar.scss
@@ -69,6 +69,7 @@ button.save-button {
 .status-history-buttons {
   display: flex;
   justify-content: space-between;
+  align-content: stretch;
   flex-wrap: wrap;
   width: 100%;
 
@@ -76,6 +77,15 @@ button.save-button {
     // Have to set button width on the dropdown wrapper instead of the
     // button itself.
     width: $width-button-half-column;
+
+    // Have to set height on toggle hierarchy to make sure align-content: stretch actually stretches the dropdown button.
+    .status-dropdown__control {
+      height: 100%;
+
+      .button, button {
+        height: 100%;
+      }
+    }
 
     .dropdown-button {
       width: 100%;


### PR DESCRIPTION
Discovered while working on DAH-564

Before the status update buttons could be different heights if one was multiline and the other was not. This change makes it so they are always the same height.

### Screenshot: after the fix
<img width="397" alt="- 2020-11-30 at 11 54 01 AM" src="https://user-images.githubusercontent.com/64036574/100657185-c0a63000-3302-11eb-927e-33d74ce3510e.png">
Note that in this screenshot, the processing button is taller even though processing isn't wrapped to multiple lines. Before this change, the buttons would be different sizes

### Screenshot: when dropdown is longer than comment button
<img width="387" alt="- 2020-11-30 at 11 55 52 AM" src="https://user-images.githubusercontent.com/64036574/100657499-21356d00-3303-11eb-8b97-679ccf2bbebb.png">
